### PR TITLE
Underline links on hover instead of changing font weight

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -12,3 +12,8 @@ ul.navigation {
     list-style-type: none;
     padding-inline-start: 20px;
 }
+
+a:hover {
+    font-weight: inherit;
+    text-decoration: underline;
+}


### PR DESCRIPTION
Thanks for taking this on, @dabrahams! This promises to be a valuable and important resource to Swift developers.

This is a quick PR to resolve a small design quirk of how the Jekyll-minimal theme styles `a` tags when you mouse over them. Changing the font weight like this changes the intrinsic size of the inline element, which causes paragraphs and surrounding elements to reflow in a way that I found distracting.

![link-hover-effect](https://user-images.githubusercontent.com/7659/87875135-e9e1a780-c983-11ea-8c01-2fab29700d7a.gif)

Here's what it looks like with the patch applied:

![link-hover-after](https://user-images.githubusercontent.com/7659/87875193-5eb4e180-c984-11ea-8918-2699383efaae.gif)
