### PR TITLE
Moving the CSS Modifications into their Own Branch and PR

### DIFF
--- a/assets/css/grammar.css
+++ b/assets/css/grammar.css
@@ -118,11 +118,3 @@ p>code,li>code,dd>code,blockquote>code,td>code{
     border-radius: 3px;
     background-color:#f7f7f7
 }
-
-
-/* Provide scrollbar when navigation menu overflows height of the viewport */
-/* TO BE MOVED TO NEW FILE */
-header {
-    overflow-y: auto;
-    max-height: 100%;
-}

--- a/assets/css/grammar.css
+++ b/assets/css/grammar.css
@@ -1,5 +1,6 @@
 /* grammar */
 
+/* styles a block of grammar */
 .grammar {
     border-left: 5px solid rgba(233,233,233,1);
     margin: 20px 0;
@@ -8,6 +9,7 @@
     background: transparent;
     font-family:"Helvetica Neue", Helvetica, Arial, Verdana, sans-serif
 }
+/* styles the title of a grammar block:  GRAMMAR OF A _____ */
 .grammar p.admonition-title {
     margin-bottom: 8px;
     font-size: 10px;
@@ -15,18 +17,22 @@
 .grammar p {
     margin: 0;
 }
+/* styles a grammar definition with a hanging first line */
 .grammar p.syntax-def {
     margin-left: 25px;
     text-indent: -25px;
 }
+/* ___ */
 .grammar span.name {
     color: rgba(128,128,128,1);
     font-style: italic;
     font-size: 15px;
 }
+/* styles the arrow symbol */
 .grammar .arrow {
     padding: 0 6px;
 }
+/* styles keywords and symbols, like ();:.{}[] */
 .grammar code {
     padding: 0;
     border: 0;
@@ -35,22 +41,28 @@
     font-weight: bold;
     padding: 0 3px;
 }
+/* styles the "opt" annotation */
 .grammar sub {
     color: rgba(128,128,128,1);
     font-size: 12px;
     font-style: italic;
-    margin-left: 0px;
+    margin-left: -4px; /* tightens to preceding text, which usually is padded */
     padding-right: 5px;
     vertical-align: baseline;
     position: relative;
     top: 0.3em;
 }
+/* add this class where (grammar sub) is too tight to preceeding text */
+.grammar sub.loosen {
+    margin-left: 0px; 
+}
+/* styles a group of grammar statements to add whitespace at bottom of group */
 .grammar .syntax-group {
     margin-bottom: 10px;
 }
 
 /* admonition */
-
+/* TO BE MOVED TO NEW FILE */
 .admonition {
     margin-left: 0px;
     border-left: solid 5px #eee;
@@ -70,7 +82,7 @@
 
 
 /* code */
-
+/* TO BE MOVED TO NEW FILE */
 code{
     white-space:pre-line
 }
@@ -107,7 +119,7 @@ p>code,li>code,dd>code,blockquote>code,td>code{
 
 
 /* section numbering */
-
+/* TO BE MOVED TO NEW FILE */
 h2 {
     text-indent: -40px;
     counter-reset: section;
@@ -139,6 +151,7 @@ h5:before {
 
 
 /* item numbering */
+/* TO BE MOVED TO NEW FILE */
 .item {
     text-indent: -20px;
     margin-bottom: -2em;
@@ -154,11 +167,13 @@ h5:before {
 
 /* alignment of body */
 /* note that item numbers and headers have a negative indent */
-
+/* TO BE MOVED TO NEW FILE */
 body {
     margin-left: 40px;
 }
 
+/* Provide scrollbar when navigation menu overflows height of the viewport */
+/* TO BE MOVED TO NEW FILE */
 header {
     overflow-y: auto;
     max-height: 100%;

--- a/assets/css/grammar.css
+++ b/assets/css/grammar.css
@@ -1,4 +1,6 @@
-/* grammar */
+/* Swift Reference */
+
+/* Styles for use with grammar */
 
 /* styles a block of grammar */
 .grammar {
@@ -117,60 +119,6 @@ p>code,li>code,dd>code,blockquote>code,td>code{
     background-color:#f7f7f7
 }
 
-
-/* section numbering */
-/* TO BE MOVED TO NEW FILE */
-h2 {
-    text-indent: -40px;
-    counter-reset: section;
-}
-h3 {
-    text-indent: -40px;
-    counter-reset: subsection;
-}
-h3:before {
-    content: counter(section) ". ";
-    counter-increment: section;
-}
-h4 {
-    text-indent: -30px;
-    counter-reset: subsubsection item; 
-}
-h4:before {
-    content: counter(section) "." counter(subsection) " ";
-    counter-increment: subsection;
-}
-h5 {
-    text-indent: -20px;
-    counter-reset: item;
-}
-h5:before {
-    content: counter(section) "." counter(subsection) "." counter(subsubsection) " ";
-    counter-increment: subsubsection;
-}
-
-
-/* item numbering */
-/* TO BE MOVED TO NEW FILE */
-.item {
-    text-indent: -20px;
-    margin-bottom: -2em;
-    font-style: italic;
-    font-size: 0.7em;
-    color: blue;
-}
-.item:before {
-    content: counter(item);
-    counter-increment: item;
-}
-
-
-/* alignment of body */
-/* note that item numbers and headers have a negative indent */
-/* TO BE MOVED TO NEW FILE */
-body {
-    margin-left: 40px;
-}
 
 /* Provide scrollbar when navigation menu overflows height of the viewport */
 /* TO BE MOVED TO NEW FILE */

--- a/assets/css/headings.css
+++ b/assets/css/headings.css
@@ -1,0 +1,42 @@
+/* Swift Reference */
+
+/* Styles for use with headings and similar matter */
+
+/* section numbering */
+h2 {
+    counter-reset: section;
+}
+h3 {
+    counter-reset: subsection;
+}
+h3:before {
+    content: counter(section) ". ";
+    counter-increment: section;
+}
+h4 {
+    counter-reset: subsubsection item; 
+}
+h4:before {
+    content: counter(section) "." counter(subsection) " ";
+    counter-increment: subsection;
+}
+h5 {
+    counter-reset: item;
+}
+h5:before {
+    content: counter(section) "." counter(subsection) "." counter(subsubsection) " ";
+    counter-increment: subsubsection;
+}
+
+/* paragraph numbering in left margin */
+.item {
+    text-indent: -20px;
+    margin-bottom: -2em;
+    font-style: italic;
+    font-size: 0.7em;
+    color: blue;
+}
+.item:before {
+    content: counter(item);
+    counter-increment: item;
+}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -14,7 +14,14 @@ ul.navigation {
     padding-inline-start: 20px;
 }
 
+/* overrides jekyll hover-over-link behavior */
 a:hover {
     font-weight: inherit;
     text-decoration: underline;
+}
+
+/* adds scrollbar when navigation menu overflows height of the viewport */
+header {
+    overflow-y: auto;
+    max-height: 100%;
 }

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -2,6 +2,7 @@
 ---
 @import "{{ site.theme_name }}";
 @import "grammar.css";
+@import "headings.css";
 
 ul.navigation {
     list-style-type: none;


### PR DESCRIPTION
I've moved the css changes out of the StatementsWorkingBranch into a new branch and PR.  Hopefully, doing so will allow for a less chaotic process.

Created a headings.css file, and moved the headings and numbing styles into it.

Modified the headings and body styles to eliminate indenting.

Added an import in the style.scss file to bring in the headings.css styles.

Moved the navigation overflow scrollbar style into the style.scss file.

Added numerous comments to explain the purpose of most of the styles being used.

There are more changes to be made to get these styles to a place consistent with Dave's comments.  In the meantime, hopefully, we can merge these changes into master, and then work on refining them as we go.
